### PR TITLE
Eigen3 dependency

### DIFF
--- a/summon-fpga-tools.sh
+++ b/summon-fpga-tools.sh
@@ -17,7 +17,7 @@
 #
 # apt-get install flex bison libgmp3-dev libmpfr-dev libncurses5-dev \
 # libmpc-dev autoconf texinfo build-essential libftdi-dev zlib1g-dev git \
-# gperf
+# gperf libeigen3-dev
 #
 # Or on Ubuntu Maverick give `apt-get build-dep gcc-4.5` a try.
 #


### PR DESCRIPTION
need to add the Eigen3 dev dependency to the list

'''CMake Error at CMakeLists.txt:193 (find_package):
  Could not find a package configuration file provided by "Eigen3" with any
  of the following names:

    Eigen3Config.cmake
    eigen3-config.cmake

  Add the installation prefix of "Eigen3" to CMAKE_PREFIX_PATH or set
  "Eigen3_DIR" to a directory containing one of the above files.  If "Eigen3"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!